### PR TITLE
refactor: Error details are now map[string]interface{}

### DIFF
--- a/error.go
+++ b/error.go
@@ -52,5 +52,5 @@ type statusCarrier interface {
 // detailsCarrier can be implemented by an error to support error contexts.
 type detailsCarrier interface {
 	// Details returns details on the error, if applicable.
-	Details() map[string][]interface{}
+	Details() map[string]interface{}
 }

--- a/error_default.go
+++ b/error_default.go
@@ -11,13 +11,13 @@ import (
 )
 
 type DefaultError struct {
-	CodeField    int                      `json:"code,omitempty"`
-	StatusField  string                   `json:"status,omitempty"`
-	RIDField     string                   `json:"request,omitempty"`
-	ReasonField  string                   `json:"reason,omitempty"`
-	DebugField   string                   `json:"debug,omitempty"`
-	DetailsField map[string][]interface{} `json:"details,omitempty"`
-	ErrorField   string                   `json:"message"`
+	CodeField    int                    `json:"code,omitempty"`
+	StatusField  string                 `json:"status,omitempty"`
+	RIDField     string                 `json:"request,omitempty"`
+	ReasonField  string                 `json:"reason,omitempty"`
+	DebugField   string                 `json:"debug,omitempty"`
+	DetailsField map[string]interface{} `json:"details,omitempty"`
+	ErrorField   string                 `json:"message"`
 
 	trace errors.StackTrace
 }
@@ -58,7 +58,7 @@ func (e *DefaultError) Debug() string {
 	return e.DebugField
 }
 
-func (e *DefaultError) Details() map[string][]interface{} {
+func (e *DefaultError) Details() map[string]interface{} {
 	return e.DetailsField
 }
 
@@ -96,12 +96,21 @@ func (e *DefaultError) WithDebug(debug string) *DefaultError {
 	return &err
 }
 
-func (e *DefaultError) WithDetail(key string, value ...interface{}) *DefaultError {
+func (e *DefaultError) WithDetail(key, detail string) *DefaultError {
 	err := *e
 	if err.DetailsField == nil {
-		err.DetailsField = map[string][]interface{}{}
+		err.DetailsField = map[string]interface{}{}
 	}
-	err.DetailsField[key] = append(err.DetailsField[key], value...)
+	err.DetailsField[key] = detail
+	return &err
+}
+
+func (e *DefaultError) WithDetailf(key string, message string, args ...interface{}) *DefaultError {
+	err := *e
+	if err.DetailsField == nil {
+		err.DetailsField = map[string]interface{}{}
+	}
+	err.DetailsField[key] = fmt.Sprintf(message, args...)
 	return &err
 }
 
@@ -133,7 +142,7 @@ func ToDefaultError(err error, id string) *DefaultError {
 	}
 
 	statusCode := http.StatusInternalServerError
-	details := map[string][]interface{}{}
+	details := map[string]interface{}{}
 	rid := id
 
 	if e, ok := errorsx.Cause(err).(statusCodeCarrier); ok {

--- a/error_default_test.go
+++ b/error_default_test.go
@@ -36,9 +36,9 @@ func TestToDefaultError(t *testing.T) {
 
 	t.Run("case=debug", func(t *testing.T) {
 		e := &DefaultError{
-			DetailsField: map[string][]interface{}{"foo-debug": {"bar"}},
+			DetailsField: map[string]interface{}{"foo-debug": "bar"},
 		}
-		assert.EqualValues(t, map[string][]interface{}{"foo-debug": {"bar"}}, ToDefaultError(e, "").Details())
+		assert.EqualValues(t, map[string]interface{}{"foo-debug": "bar"}, ToDefaultError(e, "").Details())
 	})
 
 	t.Run("case=debug", func(t *testing.T) {

--- a/json_test.go
+++ b/json_test.go
@@ -41,8 +41,8 @@ var (
 		ErrorField:  errors.New("foo").Error(),
 		ReasonField: "some-reason",
 		StatusField: "some-status",
-		DetailsField: map[string][]interface{}{
-			"foo": {"bar"},
+		DetailsField: map[string]interface{}{
+			"foo": "bar",
 		},
 	}
 	onlyStatusCodeError = &statusCodeError{statusCode: http.StatusNotFound, error: errors.New("foo")}


### PR DESCRIPTION
BREAKING CHANGE: DefaultError's details field changed from `map[string][]interface{}` to `map[string]interface{}`.
