### PR TITLE
chore: update repository template to 1d3bdaf2

### DIFF
--- a/.github/workflows/closed_references.yml
+++ b/.github/workflows/closed_references.yml
@@ -1,0 +1,24 @@
+name: Closed Reference Notifier
+
+on:
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+    inputs:
+      issueLimit:
+        description: Max. number of issues to create
+        required: true
+        default: '5'
+
+jobs:
+  find_closed_references:
+    runs-on: ubuntu-latest
+    name: Find closed references
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ory/closed-reference-notifier@v1.1.4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ignore: '.git,**/node_modules,docs,CHANGELOG.md,.bin'
+          issueLabels: upstream
+          issueLimit: ${{ github.event.inputs.issueLimit || '5' }}

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,21 @@
+name: Synchronize Issue Labels
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+
+jobs:
+  milestone:
+    name: Synchronize Issue Labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Synchronize Issue Labels
+        uses: ory/label-sync-action@v0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          dry: false
+          forced: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,24 @@
+name: "Close Stale Issues"
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: |
+            Thank you for opening this issue. It appears that the request for more information (e.g. providing the software version, providing logs, ...) has not yet been completed. Therefore this issue will be automatically
+            closed in 7 days, assuming that the issue has been resolved.
+          stale-pr-message: |
+            Thank you for opening this pull request. It appears that a request for e.g. information has not yet been completed. Therefore this issue will be automatically
+            closed in 7 days, assuming that the proposed change is no longer required or has otherwise been resolved.
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          only-labels: 'needs more info'
+          days-before-stale: 7
+          days-before-close: 7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ https://github.com/ory/meta/blob/master/templates/repository/CONTRIBUTING.md
 -->
 
 
-# Contributing to ORY Herodot
+# Contributing to ORY {{Project}}
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -28,9 +28,9 @@ https://github.com/ory/meta/blob/master/templates/repository/CONTRIBUTING.md
 
 ## Introduction
 
-Please note: We take ORY Herodot's security and our users' trust very
-seriously. If you believe you have found a security issue in ORY Herodot,
-please responsibly disclose by contacting us at hi@ory.sh.
+Please note: We take ORY {{Project}}'s security and our users' trust very
+seriously. If you believe you have found a security issue in ORY {{Project}},
+please responsibly disclose by contacting us at office@ory.sh.
 
 First: if you're unsure or afraid of anything, just ask or submit the issue or
 pull request anyways. You won't be yelled at for giving it your best effort. The
@@ -40,7 +40,7 @@ the way of that.
 
 That said, if you want to ensure that a pull request is likely to be merged,
 talk to us! You can find out our thoughts and ensure that your contribution
-won't clash or be obviated by ORY Herodot's normal direction. A great way to
+won't clash or be obviated by ORY {{Project}}'s normal direction. A great way to
 do this is via the [ORY Community](https://community.ory.sh/) or join the
 [ORY Chat](https://www.ory.sh/chat).
 
@@ -48,7 +48,7 @@ do this is via the [ORY Community](https://community.ory.sh/) or join the
 
 Unless you are fixing a known bug, we **strongly** recommend discussing it with
 the core team via a GitHub issue or [in our chat](https://www.ory.sh/chat)
-before getting started to ensure your work is consistent with ORY Herodot's
+before getting started to ensure your work is consistent with ORY {{Project}}'s
 roadmap and architecture.
 
 All contributions are made via pull request. Note that **all patches from all
@@ -132,7 +132,7 @@ community a safe place for you and we've got your back.
 - Private harassment is also unacceptable. No matter who you are, if you feel
   you have been or are being harassed or made uncomfortable by a community
   member, please contact one of the channel ops or a member of the ORY
-  Herodot core team immediately.
+  {{Project}} core team immediately.
 - Likewise any spamming, trolling, flaming, baiting or other attention-stealing
   behaviour is not welcome.
 


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/1d3bdaf243c166ab2ed8a6de1c33ca728ff620a3.