### PR TITLE
docs: remove reference to glide

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Herodot is used by [ORY Hydra](https://github.com/ory/hydra) and serves millions
 
 ## Installation
 
-Herodot is versioned using [glide](https://github.com/Masterminds/glide) and works best with
+Herodot is versioned using [go modules](https://blog.golang.org/using-go-modules) and works best with
 [pkg/errors](https://github.com/pkg/errors). To install it, run
 
 ```


### PR DESCRIPTION
## Proposed changes

Since https://github.com/ory/herodot/commit/971c3587ee1af2b9e86f3cf38b0cd320a889120a, seems like glide is not being used. Reading the readme today I was confused for a bit until I understood it was an old reference.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).
