### PR TITLE
docs: remove swagger annotation

### DIFF
--- a/error_default.go
+++ b/error_default.go
@@ -13,7 +13,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// swagger:model genericError
 type DefaultError struct {
 	// The error ID
 	//


### PR DESCRIPTION
The error, if written using the default JSON writer with the default error enhancer is wrapped in the `ErrorWrapper`. Therefore, `DefaultError` is not the `genericError` as used in other Ory projects. Removing this annotation all together gives every consumer the ability to do the right annotation.
Swagger overrides models, this is why it has to be removed.