### PR TITLE
chore: remove double tabs from Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 format: tools node_modules
-		.bin/goimports -w -local github.com/ory *.go . httputil
-		npm exec -- prettier --write .
+	.bin/goimports -w -local github.com/ory *.go . httputil
+	npm exec -- prettier --write .
 
 node_modules: package-lock.json
 	npm ci
 	touch node_modules
 
 tools:
-		GOBIN=$(shell pwd)/.bin/ go install github.com/ory/go-acc golang.org/x/tools/cmd/goimports github.com/jandelgado/gcov2lcov
+	GOBIN=$(shell pwd)/.bin/ go install github.com/ory/go-acc golang.org/x/tools/cmd/goimports github.com/jandelgado/gcov2lcov


### PR DESCRIPTION
Reduces the indentation of Makefiles from double tabs to single tabs.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation within the code base (if appropriate).
