### PR TITLE
fix: remove MarshalJSON implementation from DefaultError

### DIFF
--- a/error_default.go
+++ b/error_default.go
@@ -4,7 +4,6 @@
 package herodot
 
 import (
-	"encoding/json"
 	stderr "errors"
 	"fmt"
 	"io"
@@ -68,16 +67,6 @@ type DefaultError struct {
 
 	GRPCCodeField codes.Code `json:"-"`
 	err           error
-	enableDebug   bool
-}
-
-func (e *DefaultError) MarshalJSON() ([]byte, error) {
-	type alias DefaultError
-	ee := alias(*e)
-	if !ee.enableDebug {
-		ee.DebugField = ""
-	}
-	return json.Marshal(&ee)
 }
 
 // StackTrace returns the error's stack trace.

--- a/json.go
+++ b/json.go
@@ -136,11 +136,17 @@ func (h *JSONWriter) WriteErrorCode(w http.ResponseWriter, r *http.Request, code
 	if h.ErrorEnhancer != nil {
 		payload = h.ErrorEnhancer(r, err)
 	}
-	if de, ok := payload.(*DefaultError); ok {
-		de.enableDebug = h.EnableDebug
+	if de, ok := payload.(*DefaultError); ok && !h.EnableDebug {
+		de2 := *de
+		de2.DebugField = ""
+		payload = &de2
 	}
-	if de, ok := payload.(*ErrorContainer); ok {
-		de.Error.enableDebug = h.EnableDebug
+	if ec, ok := payload.(*ErrorContainer); ok && !h.EnableDebug {
+		de2 := *ec.Error
+		de2.DebugField = ""
+		ec2 := *ec
+		ec2.Error = &de2
+		payload = ec2
 	}
 
 	if err := json.NewEncoder(w).Encode(payload); err != nil {


### PR DESCRIPTION
This interferes with embedding *DefaultError in custom error structs.