### PR TITLE
fix: swagger-ignore DefaultError

### DIFF
--- a/error_default.go
+++ b/error_default.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pkg/errors"
 )
 
+// swagger:ignore
 type DefaultError struct {
 	// The error ID
 	//


### PR DESCRIPTION
Users of this library wanting to use `DefaultError` with [go-swagger](https://github.com/go-swagger/go-swagger) are expected to add this definition to their codebase for compatibility. This change completes https://github.com/ory/herodot/pull/106

```go
// swagger:model genericError
type genericError struct{ herodot.DefaultError }
```