### PR TITLE
chore: convert global mutable errors to functions to avoid data races

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(go test:*)"
+    ]
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,5 @@
 {
   "permissions": {
-    "allow": [
-      "Bash(go test:*)"
-    ]
+    "allow": ["Bash(go test:*)"]
   }
 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.24"
+          go-version: "1.25"
       - run: go test -coverprofile=coverage.out -timeout=1m ./...
       - run: go tool gcov2lcov -infile=coverage.out -outfile=coverage.lcov
       - name: Coveralls

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ licenses: .bin/licenses node_modules  # checks open-source licenses
 	.bin/licenses
 
 .bin/licenses: Makefile
-	curl https://raw.githubusercontent.com/ory/ci/master/licenses/install | sh
+	curl --retry 7 --retry-connrefused https://raw.githubusercontent.com/ory/ci/master/licenses/install | sh
 
 .bin/ory: Makefile
-	curl https://raw.githubusercontent.com/ory/meta/master/install.sh | bash -s -- -b .bin ory v0.2.2
+	curl --retry 7 --retry-connrefused https://raw.githubusercontent.com/ory/meta/master/install.sh | bash -s -- -b .bin ory v0.2.2
 	touch .bin/ory
 
 node_modules: package-lock.json

--- a/error_default.go
+++ b/error_default.go
@@ -36,6 +36,10 @@ func (*noCopy) Unlock() {}
 // A shallow copy would inadvertently share these underlying fields,
 // leading to incorrect behavior and data races in a concurrent context.
 // Consequently, all methods take the type by pointer and not by value.
+//
+// From https://go.dev/wiki/CodeReviewComments#receiver-type:
+// > If the receiver is a struct, array or slice and any of its elements is a pointer to something that might be mutating,
+// > prefer a pointer receiver, as it will make the intention clearer to the reader.
 // swagger:ignore
 type DefaultError struct {
 	_ noCopy

--- a/error_default.go
+++ b/error_default.go
@@ -40,6 +40,7 @@ func (*noCopy) Unlock() {}
 // From https://go.dev/wiki/CodeReviewComments#receiver-type:
 // > If the receiver is a struct, array or slice and any of its elements is a pointer to something that might be mutating,
 // > prefer a pointer receiver, as it will make the intention clearer to the reader.
+// > Don’t mix receiver types. Choose either pointers or struct types for all available methods.
 // swagger:ignore
 type DefaultError struct {
 	_ noCopy

--- a/error_default.go
+++ b/error_default.go
@@ -7,6 +7,7 @@ import (
 	stderr "errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -16,6 +17,20 @@ import (
 	"google.golang.org/protobuf/protoadapt"
 )
 
+// (Copied from stdlib.)
+// NoCopy may be added to structs which must not be copied
+// after the first use.
+//
+// See https://golang.org/issues/8005#issuecomment-190753527
+// for details.
+//
+// Note that it must not be embedded, due to the Lock and Unlock methods.
+type NoCopy struct{}
+
+// Lock is a no-op used by -copylocks checker from `go vet`.
+func (*NoCopy) Lock()   {}
+func (*NoCopy) Unlock() {}
+
 // DefaultError is not safe to shallow copy because it contains
 // fields which are not value types, e.g. maps.
 // A shallow copy would inadvertently share these underlying fields,
@@ -23,6 +38,7 @@ import (
 // Consequently, all methods take the type by pointer and not by value.
 // swagger:ignore
 type DefaultError struct {
+	_ NoCopy
 	// The error ID
 	//
 	// Useful when trying to identify various errors in application logic.
@@ -72,6 +88,22 @@ type DefaultError struct {
 
 	GRPCCodeField codes.Code `json:"-"`
 	err           error
+}
+
+func (e *DefaultError) Clone() *DefaultError {
+	res := &DefaultError{
+		IDField:       e.IDField,
+		CodeField:     e.CodeField,
+		StatusField:   e.StatusField,
+		RIDField:      e.RIDField,
+		ReasonField:   e.ReasonField,
+		DebugField:    e.DebugField,
+		DetailsField:  maps.Clone(e.DetailsField),
+		ErrorField:    e.ErrorField,
+		GRPCCodeField: e.GRPCCodeField,
+		err:           e.err,
+	}
+	return res
 }
 
 // StackTrace returns the error's stack trace.
@@ -239,7 +271,7 @@ func rootCauses(err fieldViolationError) []fieldViolationError {
 	return []fieldViolationError{err}
 }
 
-func (e DefaultError) fieldViolations() (fv []*errdetails.BadRequest_FieldViolation) {
+func (e *DefaultError) fieldViolations() (fv []*errdetails.BadRequest_FieldViolation) {
 	err, ok := e.err.(multiError)
 	if !ok {
 		return

--- a/error_default.go
+++ b/error_default.go
@@ -38,6 +38,7 @@ func (*noCopy) Unlock() {}
 // Consequently, all methods take the type by pointer and not by value.
 //
 // From https://go.dev/wiki/CodeReviewComments#receiver-type:
+// > Can function or methods, either concurrently or when called from this method, be mutating the receiver? A value type creates a copy of the receiver when the method is invoked, so outside updates will not be applied to this receiver. If changes must be visible in the original receiver, the receiver must be a pointer.
 // > If the receiver is a struct, array or slice and any of its elements is a pointer to something that might be mutating,
 // > prefer a pointer receiver, as it will make the intention clearer to the reader.
 // > Don’t mix receiver types. Choose either pointers or struct types for all available methods.

--- a/error_default.go
+++ b/error_default.go
@@ -18,18 +18,18 @@ import (
 )
 
 // (Copied from stdlib.)
-// NoCopy may be added to structs which must not be copied
+// noCopy may be added to structs which must not be copied
 // after the first use.
 //
 // See https://golang.org/issues/8005#issuecomment-190753527
 // for details.
 //
 // Note that it must not be embedded, due to the Lock and Unlock methods.
-type NoCopy struct{}
+type noCopy struct{}
 
 // Lock is a no-op used by -copylocks checker from `go vet`.
-func (*NoCopy) Lock()   {}
-func (*NoCopy) Unlock() {}
+func (*noCopy) Lock()   {}
+func (*noCopy) Unlock() {}
 
 // DefaultError is not safe to shallow copy because it contains
 // fields which are not value types, e.g. maps.
@@ -38,7 +38,7 @@ func (*NoCopy) Unlock() {}
 // Consequently, all methods take the type by pointer and not by value.
 // swagger:ignore
 type DefaultError struct {
-	_ NoCopy
+	_ noCopy
 	// The error ID
 	//
 	// Useful when trying to identify various errors in application logic.
@@ -92,12 +92,13 @@ type DefaultError struct {
 
 func (e *DefaultError) Clone() *DefaultError {
 	res := &DefaultError{
-		IDField:       e.IDField,
-		CodeField:     e.CodeField,
-		StatusField:   e.StatusField,
-		RIDField:      e.RIDField,
-		ReasonField:   e.ReasonField,
-		DebugField:    e.DebugField,
+		IDField:     e.IDField,
+		CodeField:   e.CodeField,
+		StatusField: e.StatusField,
+		RIDField:    e.RIDField,
+		ReasonField: e.ReasonField,
+		DebugField:  e.DebugField,
+		// Fingers crossed that the values in the map are safe to shallow copy.
 		DetailsField:  maps.Clone(e.DetailsField),
 		ErrorField:    e.ErrorField,
 		GRPCCodeField: e.GRPCCodeField,

--- a/error_default.go
+++ b/error_default.go
@@ -128,16 +128,19 @@ func (e *DefaultError) Wrap(err error) {
 	e.err = err
 }
 
+// WithWrap sets the wrapped error. Mutates and returns the receiver.
 func (e *DefaultError) WithWrap(err error) *DefaultError {
 	e.err = err
 	return e
 }
 
+// WithID sets the error ID. Mutates and returns the receiver.
 func (e *DefaultError) WithID(id string) *DefaultError {
 	e.IDField = id
 	return e
 }
 
+// WithTrace sets the wrapped error, capturing a stack trace if one is not already present. Mutates and returns the receiver.
 func (e *DefaultError) WithTrace(err error) *DefaultError {
 	if st := stackTracer(nil); !stderr.As(e.err, &st) {
 		e.Wrap(errors.WithStack(err))
@@ -292,33 +295,40 @@ func (e *DefaultError) fieldViolations() (fv []*errdetails.BadRequest_FieldViola
 	return
 }
 
+// WithReason sets the human-readable reason. Mutates and returns the receiver.
 func (e *DefaultError) WithReason(reason string) *DefaultError {
 	e.ReasonField = reason
 	return e
 }
 
+// WithReasonf sets the human-readable reason using a format string. Mutates and returns the receiver.
 func (e *DefaultError) WithReasonf(reason string, args ...interface{}) *DefaultError {
 	return e.WithReason(fmt.Sprintf(reason, args...))
 }
 
+// WithError sets the error message. Mutates and returns the receiver.
 func (e *DefaultError) WithError(message string) *DefaultError {
 	e.ErrorField = message
 	return e
 }
 
+// WithErrorf sets the error message using a format string. Mutates and returns the receiver.
 func (e *DefaultError) WithErrorf(message string, args ...interface{}) *DefaultError {
 	return e.WithError(fmt.Sprintf(message, args...))
 }
 
+// WithDebugf sets the debug information using a format string. Mutates and returns the receiver.
 func (e *DefaultError) WithDebugf(debug string, args ...interface{}) *DefaultError {
 	return e.WithDebug(fmt.Sprintf(debug, args...))
 }
 
+// WithDebug sets the debug information. Mutates and returns the receiver.
 func (e *DefaultError) WithDebug(debug string) *DefaultError {
 	e.DebugField = debug
 	return e
 }
 
+// WithDetail adds a key-value pair to the error details map. Mutates and returns the receiver.
 func (e *DefaultError) WithDetail(key string, detail interface{}) *DefaultError {
 	if e.DetailsField == nil {
 		e.DetailsField = map[string]interface{}{}
@@ -327,6 +337,7 @@ func (e *DefaultError) WithDetail(key string, detail interface{}) *DefaultError 
 	return e
 }
 
+// WithDetailf adds a key-value pair to the error details map, formatting the value as a string. Mutates and returns the receiver.
 func (e *DefaultError) WithDetailf(key string, message string, args ...interface{}) *DefaultError {
 	if e.DetailsField == nil {
 		e.DetailsField = map[string]interface{}{}

--- a/error_default.go
+++ b/error_default.go
@@ -16,6 +16,11 @@ import (
 	"google.golang.org/protobuf/protoadapt"
 )
 
+// DefaultError is not safe to shallow copy because it contains
+// fields which are not value types, e.g. maps.
+// A shallow copy would inadvertently share these underlying fields,
+// leading to incorrect behavior and data races in a concurrent context.
+// Consequently, all methods take the type by pointer and not by value.
 // swagger:ignore
 type DefaultError struct {
 	// The error ID
@@ -82,7 +87,7 @@ func (e *DefaultError) StackTrace() (trace errors.StackTrace) {
 	return
 }
 
-func (e DefaultError) Unwrap() error {
+func (e *DefaultError) Unwrap() error {
 	return e.err
 }
 
@@ -90,14 +95,14 @@ func (e *DefaultError) Wrap(err error) {
 	e.err = err
 }
 
-func (e DefaultError) WithWrap(err error) *DefaultError {
+func (e *DefaultError) WithWrap(err error) *DefaultError {
 	e.err = err
-	return &e
+	return e
 }
 
-func (e DefaultError) WithID(id string) *DefaultError {
+func (e *DefaultError) WithID(id string) *DefaultError {
 	e.IDField = id
-	return &e
+	return e
 }
 
 func (e *DefaultError) WithTrace(err error) *DefaultError {
@@ -109,13 +114,8 @@ func (e *DefaultError) WithTrace(err error) *DefaultError {
 	return e
 }
 
-func (e DefaultError) Is(err error) bool {
+func (e *DefaultError) Is(err error) bool {
 	switch te := err.(type) {
-	case DefaultError:
-		return e.ErrorField == te.ErrorField &&
-			e.StatusField == te.StatusField &&
-			e.IDField == te.IDField &&
-			e.CodeField == te.CodeField
 	case *DefaultError:
 		return e.ErrorField == te.ErrorField &&
 			e.StatusField == te.StatusField &&
@@ -126,39 +126,39 @@ func (e DefaultError) Is(err error) bool {
 	}
 }
 
-func (e DefaultError) Status() string {
+func (e *DefaultError) Status() string {
 	return e.StatusField
 }
 
-func (e DefaultError) ID() string {
+func (e *DefaultError) ID() string {
 	return e.IDField
 }
 
-func (e DefaultError) Error() string {
+func (e *DefaultError) Error() string {
 	return e.ErrorField
 }
 
-func (e DefaultError) RequestID() string {
+func (e *DefaultError) RequestID() string {
 	return e.RIDField
 }
 
-func (e DefaultError) Reason() string {
+func (e *DefaultError) Reason() string {
 	return e.ReasonField
 }
 
-func (e DefaultError) Debug() string {
+func (e *DefaultError) Debug() string {
 	return e.DebugField
 }
 
-func (e DefaultError) Details() map[string]interface{} {
+func (e *DefaultError) Details() map[string]interface{} {
 	return e.DetailsField
 }
 
-func (e DefaultError) StatusCode() int {
+func (e *DefaultError) StatusCode() int {
 	return e.CodeField
 }
 
-func (e DefaultError) GRPCStatus() *status.Status {
+func (e *DefaultError) GRPCStatus() *status.Status {
 	s := status.New(e.GRPCCodeField, e.Error())
 
 	st := e.StackTrace()
@@ -259,50 +259,50 @@ func (e DefaultError) fieldViolations() (fv []*errdetails.BadRequest_FieldViolat
 	return
 }
 
-func (e DefaultError) WithReason(reason string) *DefaultError {
+func (e *DefaultError) WithReason(reason string) *DefaultError {
 	e.ReasonField = reason
-	return &e
+	return e
 }
 
-func (e DefaultError) WithReasonf(reason string, args ...interface{}) *DefaultError {
+func (e *DefaultError) WithReasonf(reason string, args ...interface{}) *DefaultError {
 	return e.WithReason(fmt.Sprintf(reason, args...))
 }
 
-func (e DefaultError) WithError(message string) *DefaultError {
+func (e *DefaultError) WithError(message string) *DefaultError {
 	e.ErrorField = message
-	return &e
+	return e
 }
 
-func (e DefaultError) WithErrorf(message string, args ...interface{}) *DefaultError {
+func (e *DefaultError) WithErrorf(message string, args ...interface{}) *DefaultError {
 	return e.WithError(fmt.Sprintf(message, args...))
 }
 
-func (e DefaultError) WithDebugf(debug string, args ...interface{}) *DefaultError {
+func (e *DefaultError) WithDebugf(debug string, args ...interface{}) *DefaultError {
 	return e.WithDebug(fmt.Sprintf(debug, args...))
 }
 
-func (e DefaultError) WithDebug(debug string) *DefaultError {
+func (e *DefaultError) WithDebug(debug string) *DefaultError {
 	e.DebugField = debug
-	return &e
+	return e
 }
 
-func (e DefaultError) WithDetail(key string, detail interface{}) *DefaultError {
+func (e *DefaultError) WithDetail(key string, detail interface{}) *DefaultError {
 	if e.DetailsField == nil {
 		e.DetailsField = map[string]interface{}{}
 	}
 	e.DetailsField[key] = detail
-	return &e
+	return e
 }
 
-func (e DefaultError) WithDetailf(key string, message string, args ...interface{}) *DefaultError {
+func (e *DefaultError) WithDetailf(key string, message string, args ...interface{}) *DefaultError {
 	if e.DetailsField == nil {
 		e.DetailsField = map[string]interface{}{}
 	}
 	e.DetailsField[key] = fmt.Sprintf(message, args...)
-	return &e
+	return e
 }
 
-func (e DefaultError) Format(s fmt.State, verb rune) {
+func (e *DefaultError) Format(s fmt.State, verb rune) {
 	switch verb {
 	case 'v':
 		if s.Flag('+') {

--- a/error_default_test.go
+++ b/error_default_test.go
@@ -18,6 +18,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func makeSomeError() *DefaultError {
+	return &DefaultError{
+		ErrorField:    "message",
+		GRPCCodeField: codes.InvalidArgument,
+		DebugField:    "debug",
+		ReasonField:   "reason",
+		RIDField:      "request_id",
+	}
+}
+
 func TestToDefaultError(t *testing.T) {
 	t.Run("case=stack", func(t *testing.T) {
 		e := errors.New("hi")
@@ -101,13 +111,7 @@ func TestToDefaultError(t *testing.T) {
 			&errdetails.RequestInfo{RequestId: "request_id"},
 		)
 
-		status := DefaultError{
-			ErrorField:    "message",
-			GRPCCodeField: codes.InvalidArgument,
-			DebugField:    "debug",
-			ReasonField:   "reason",
-			RIDField:      "request_id",
-		}.GRPCStatus()
+		status := makeSomeError().GRPCStatus()
 
 		assert.Equal(t, expected, status)
 	})

--- a/error_default_test.go
+++ b/error_default_test.go
@@ -77,13 +77,11 @@ func TestToDefaultError(t *testing.T) {
 		assert.EqualValues(t, map[string]interface{}{"foo-debug": "bar"}, ToDefaultError(e, "").Details())
 	})
 
-	t.Run("case=details copies map", func(t *testing.T) {
-		eBar := DefaultError{}.WithDetail("foo", "bar")
+	t.Run("case=details uses the same map", func(t *testing.T) {
+		eBar := (&DefaultError{}).WithDetail("foo", "bar")
 		eBaz := eBar.WithDetail("foo", "baz")
 		eBazBar := eBaz.WithDetailf("bar", "baz%s", "bar")
-		assert.EqualValues(t, map[string]interface{}{"foo": "bar"}, ToDefaultError(eBar, "").Details())
-		assert.EqualValues(t, map[string]interface{}{"foo": "baz"}, ToDefaultError(eBaz, "").Details())
-		assert.EqualValues(t, map[string]interface{}{"foo": "baz", "bar": "bazbar"}, ToDefaultError(eBazBar, "").Details())
+		assert.Equal(t, eBaz.Details(), eBazBar.Details())
 	})
 
 	t.Run("case=rid", func(t *testing.T) {

--- a/error_defaults.go
+++ b/error_defaults.go
@@ -9,68 +9,86 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
-var ErrNotFound = DefaultError{
-	StatusField:   http.StatusText(http.StatusNotFound),
-	ErrorField:    "The requested resource could not be found",
-	CodeField:     http.StatusNotFound,
-	GRPCCodeField: codes.NotFound,
+func ErrNotFound() *DefaultError {
+	return &DefaultError{
+		StatusField:   http.StatusText(http.StatusNotFound),
+		ErrorField:    "The requested resource could not be found",
+		CodeField:     http.StatusNotFound,
+		GRPCCodeField: codes.NotFound,
+	}
 }
 
-var ErrUnauthorized = DefaultError{
-	StatusField:   http.StatusText(http.StatusUnauthorized),
-	ErrorField:    "The request could not be authorized",
-	CodeField:     http.StatusUnauthorized,
-	GRPCCodeField: codes.Unauthenticated,
+func ErrUnauthorized() *DefaultError {
+	return &DefaultError{
+		StatusField:   http.StatusText(http.StatusUnauthorized),
+		ErrorField:    "The request could not be authorized",
+		CodeField:     http.StatusUnauthorized,
+		GRPCCodeField: codes.Unauthenticated,
+	}
 }
 
-var ErrForbidden = DefaultError{
-	StatusField:   http.StatusText(http.StatusForbidden),
-	ErrorField:    "The requested action was forbidden",
-	CodeField:     http.StatusForbidden,
-	GRPCCodeField: codes.PermissionDenied,
+func ErrForbidden() *DefaultError {
+	return &DefaultError{
+		StatusField:   http.StatusText(http.StatusForbidden),
+		ErrorField:    "The requested action was forbidden",
+		CodeField:     http.StatusForbidden,
+		GRPCCodeField: codes.PermissionDenied,
+	}
 }
 
-var ErrInternalServerError = DefaultError{
-	StatusField:   http.StatusText(http.StatusInternalServerError),
-	ErrorField:    "An internal server error occurred, please contact the system administrator",
-	CodeField:     http.StatusInternalServerError,
-	GRPCCodeField: codes.Internal,
+func ErrInternalServerError() *DefaultError {
+	return &DefaultError{
+		StatusField:   http.StatusText(http.StatusInternalServerError),
+		ErrorField:    "An internal server error occurred, please contact the system administrator",
+		CodeField:     http.StatusInternalServerError,
+		GRPCCodeField: codes.Internal,
+	}
 }
 
-var ErrBadRequest = DefaultError{
-	StatusField:   http.StatusText(http.StatusBadRequest),
-	ErrorField:    "The request was malformed or contained invalid parameters",
-	CodeField:     http.StatusBadRequest,
-	GRPCCodeField: codes.InvalidArgument,
+func ErrBadRequest() *DefaultError {
+	return &DefaultError{
+		StatusField:   http.StatusText(http.StatusBadRequest),
+		ErrorField:    "The request was malformed or contained invalid parameters",
+		CodeField:     http.StatusBadRequest,
+		GRPCCodeField: codes.InvalidArgument,
+	}
 }
 
-var ErrUnsupportedMediaType = DefaultError{
-	StatusField:   http.StatusText(http.StatusUnsupportedMediaType),
-	ErrorField:    "The request is using an unknown content type",
-	CodeField:     http.StatusUnsupportedMediaType,
-	GRPCCodeField: codes.InvalidArgument,
+func ErrUnsupportedMediaType() *DefaultError {
+	return &DefaultError{
+		StatusField:   http.StatusText(http.StatusUnsupportedMediaType),
+		ErrorField:    "The request is using an unknown content type",
+		CodeField:     http.StatusUnsupportedMediaType,
+		GRPCCodeField: codes.InvalidArgument,
+	}
 }
 
-var ErrConflict = DefaultError{
-	StatusField:   http.StatusText(http.StatusConflict),
-	ErrorField:    "The resource could not be created due to a conflict",
-	CodeField:     http.StatusConflict,
-	GRPCCodeField: codes.FailedPrecondition,
+func ErrConflict() *DefaultError {
+	return &DefaultError{
+		StatusField:   http.StatusText(http.StatusConflict),
+		ErrorField:    "The resource could not be created due to a conflict",
+		CodeField:     http.StatusConflict,
+		GRPCCodeField: codes.FailedPrecondition,
+	}
 }
 
-var ErrMisconfiguration = DefaultError{
-	IDField:       "invalid_configuration",
-	StatusField:   http.StatusText(http.StatusInternalServerError),
-	ErrorField:    "Invalid configuration",
-	ReasonField:   "One or more configuration values are invalid. Please report this to the system administrator.",
-	CodeField:     http.StatusInternalServerError,
-	GRPCCodeField: codes.Internal,
+func ErrMisconfiguration() *DefaultError {
+	return &DefaultError{
+		IDField:       "invalid_configuration",
+		StatusField:   http.StatusText(http.StatusInternalServerError),
+		ErrorField:    "Invalid configuration",
+		ReasonField:   "One or more configuration values are invalid. Please report this to the system administrator.",
+		CodeField:     http.StatusInternalServerError,
+		GRPCCodeField: codes.Internal,
+	}
 }
 
-var ErrUpstreamError = DefaultError{
-	IDField:     "upstream_error",
-	StatusField: http.StatusText(http.StatusBadGateway),
-	ErrorField:  "Upstream error",
-	ReasonField: "An upstream server encountered an error or returned a malformed or unexpected response.",
-	CodeField:   http.StatusBadGateway,
+func ErrUpstreamError() *DefaultError {
+	return &DefaultError{
+		IDField:     "upstream_error",
+		StatusField: http.StatusText(http.StatusBadGateway),
+		ErrorField:  "Upstream error",
+		ReasonField: "An upstream server encountered an error or returned a malformed or unexpected response.",
+		CodeField:   http.StatusBadGateway,
+	}
 }

--- a/error_defaults_test.go
+++ b/error_defaults_test.go
@@ -28,7 +28,7 @@ func TestErrorFunctionsNoDataRace(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
-	for i := 0; i < goroutines; i++ {
+	for i := range goroutines {
 		wg.Go(func() {
 			fn := constructors[i%len(constructors)]
 			err := fn().

--- a/error_defaults_test.go
+++ b/error_defaults_test.go
@@ -1,0 +1,43 @@
+// Copyright © 2023 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+package herodot
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestErrorFunctionsNoDataRace verifies that concurrent use of the error
+// constructor functions does not cause data races. Each call must return an
+// independent instance so that request-scoped mutations (e.g. WithDetail,
+// WithReason) do not bleed between goroutines.
+func TestErrorFunctionsNoDataRace(t *testing.T) {
+	const goroutines = 200
+
+	constructors := []func() *DefaultError{
+		ErrNotFound,
+		ErrUnauthorized,
+		ErrForbidden,
+		ErrInternalServerError,
+		ErrBadRequest,
+		ErrUnsupportedMediaType,
+		ErrConflict,
+		ErrMisconfiguration,
+		ErrUpstreamError,
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Go(func() {
+			fn := constructors[i%len(constructors)]
+			err := fn().
+				WithDetail("goroutine", i).
+				WithReason("concurrent test")
+			// Read back the details to exercise the map on both sides.
+			_ = err.Details()
+			_ = err.Reason()
+		})
+	}
+	wg.Wait()
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ory/herodot
 
-go 1.24
+go 1.25
 
 require (
 	github.com/pkg/errors v0.9.1

--- a/grpc_unwrap_interceptors_test.go
+++ b/grpc_unwrap_interceptors_test.go
@@ -26,7 +26,7 @@ type testingGreeter struct {
 
 func (g *testingGreeter) SayHello(context.Context, *internal.HelloRequest) (*internal.HelloReply, error) {
 	if g.shouldErr {
-		return nil, errors.WithStack(ErrInternalServerError)
+		return nil, errors.WithStack(ErrInternalServerError())
 	}
 	return &internal.HelloReply{Message: "see, no error"}, nil
 }

--- a/json.go
+++ b/json.go
@@ -78,7 +78,7 @@ func Scrub5xxJSONErrorEnhancer(r *http.Request, err error) interface{} {
 	}
 
 	// We have some other error, which we always want to scrub.
-	return &ErrorContainer{Error: ToDefaultError(&ErrInternalServerError, r.Header.Get("X-Request-ID"))}
+	return &ErrorContainer{Error: ToDefaultError(ErrInternalServerError(), r.Header.Get("X-Request-ID"))}
 }
 
 func scrub5xxError(err *DefaultError) *ErrorContainer {

--- a/json.go
+++ b/json.go
@@ -64,9 +64,9 @@ func defaultJSONErrorEnhancer(r *http.Request, err error) interface{} {
 func Scrub5xxJSONErrorEnhancer(r *http.Request, err error) interface{} {
 	payload := defaultJSONErrorEnhancer(r, err)
 
-	if de, ok := payload.(DefaultError); ok {
+	if de, ok := payload.(*DefaultError); ok {
 		if de.StatusCode() >= 500 {
-			return scrub5xxError(&de)
+			return scrub5xxError(de)
 		}
 		return payload
 	}
@@ -167,15 +167,15 @@ func (h *JSONWriter) WriteErrorCode(w http.ResponseWriter, r *http.Request, code
 		payload = h.ErrorEnhancer(r, err)
 	}
 	if de, ok := payload.(*DefaultError); ok && !h.EnableDebug {
-		de2 := *de
+		de2 := de.Clone()
 		de2.DebugField = ""
-		payload = &de2
+		payload = de2
 	}
 	if ec, ok := payload.(*ErrorContainer); ok && !h.EnableDebug {
-		de2 := *ec.Error
+		de2 := ec.Error.Clone()
 		de2.DebugField = ""
 		ec2 := *ec
-		ec2.Error = &de2
+		ec2.Error = de2
 		payload = ec2
 	}
 

--- a/json_test.go
+++ b/json_test.go
@@ -20,8 +20,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var (
-	exampleError = &DefaultError{
+func exampleError() *DefaultError {
+	return &DefaultError{
 		CodeField:   http.StatusNotFound,
 		ErrorField:  "foo",
 		ReasonField: "some-reason",
@@ -30,8 +30,11 @@ var (
 			"foo": "bar",
 		},
 	}
-	onlyStatusCodeError = &statusCodeError{statusCode: http.StatusNotFound, error: errors.New("foo")}
-)
+}
+
+func newOnlyStatusCodeError() *statusCodeError {
+	return &statusCodeError{statusCode: http.StatusNotFound, error: errors.New("foo")}
+}
 
 type statusCodeError struct {
 	statusCode int
@@ -49,15 +52,15 @@ func TestWriteError(t *testing.T) {
 		expect *DefaultError
 	}{
 		{
-			err:    exampleError,
-			expect: exampleError,
+			err:    exampleError(),
+			expect: exampleError(),
 		},
 		{
-			err:    errors.WithStack(exampleError),
-			expect: exampleError,
+			err:    errors.WithStack(exampleError()),
+			expect: exampleError(),
 		},
 		{
-			err: onlyStatusCodeError,
+			err: newOnlyStatusCodeError(),
 			expect: &DefaultError{
 				StatusField: http.StatusText(http.StatusNotFound),
 				CodeField:   http.StatusNotFound,
@@ -65,7 +68,7 @@ func TestWriteError(t *testing.T) {
 			},
 		},
 		{
-			err: errors.WithStack(onlyStatusCodeError),
+			err: errors.WithStack(newOnlyStatusCodeError()),
 			expect: &DefaultError{
 				StatusField: http.StatusText(http.StatusNotFound),
 				CodeField:   http.StatusNotFound,
@@ -139,15 +142,15 @@ func TestWriteError(t *testing.T) {
 			expect *DefaultError
 		}{
 			{
-				err:    exampleError,
-				expect: exampleError,
+				err:    exampleError(),
+				expect: exampleError(),
 			},
 			{
-				err:    errors.WithStack(exampleError),
-				expect: exampleError,
+				err:    errors.WithStack(exampleError()),
+				expect: exampleError(),
 			},
 			{
-				err: onlyStatusCodeError,
+				err: newOnlyStatusCodeError(),
 				expect: &DefaultError{
 					StatusField: http.StatusText(http.StatusNotFound),
 					CodeField:   http.StatusNotFound,
@@ -155,7 +158,7 @@ func TestWriteError(t *testing.T) {
 				},
 			},
 			{
-				err: errors.WithStack(onlyStatusCodeError),
+				err: errors.WithStack(newOnlyStatusCodeError()),
 				expect: &DefaultError{
 					StatusField: http.StatusText(http.StatusNotFound),
 					CodeField:   http.StatusNotFound,
@@ -294,7 +297,7 @@ func TestWriteErrorCode(t *testing.T) {
 	h := NewJSONWriter(nil)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		r.Header.Set("X-Request-ID", "foo")
-		h.WriteErrorCode(w, r, 0, errors.Wrap(exampleError, ""))
+		h.WriteErrorCode(w, r, 0, errors.Wrap(exampleError(), ""))
 	}))
 	defer ts.Close()
 

--- a/json_test.go
+++ b/json_test.go
@@ -97,7 +97,7 @@ func TestWriteError(t *testing.T) {
 			},
 		},
 		{
-			err: ErrInternalServerError.WithTrace(tracedErr).WithReasonf("Unable to prepare JSON Schema for HTTP Post Body Form parsing: %s", tracedErr).WithDebugf("%+v", tracedErr),
+			err: ErrInternalServerError().WithTrace(tracedErr).WithReasonf("Unable to prepare JSON Schema for HTTP Post Body Form parsing: %s", tracedErr).WithDebugf("%+v", tracedErr),
 			expect: &DefaultError{
 				ReasonField: fmt.Sprintf("Unable to prepare JSON Schema for HTTP Post Body Form parsing: %s", tracedErr),
 				StatusField: http.StatusText(http.StatusInternalServerError),
@@ -187,7 +187,7 @@ func TestWriteError(t *testing.T) {
 				},
 			},
 			{
-				err: ErrInternalServerError.WithTrace(tracedErr).WithReasonf("Unable to prepare JSON Schema for HTTP Post Body Form parsing: %s", tracedErr).WithDebugf("%+v", tracedErr),
+				err: ErrInternalServerError().WithTrace(tracedErr).WithReasonf("Unable to prepare JSON Schema for HTTP Post Body Form parsing: %s", tracedErr).WithDebugf("%+v", tracedErr),
 				expect: &DefaultError{
 					ReasonField: "", // scrubbed
 					StatusField: http.StatusText(http.StatusInternalServerError),

--- a/json_test.go
+++ b/json_test.go
@@ -434,12 +434,12 @@ func TestOryErrorIDHeader(t *testing.T) {
 	}{
 		{
 			name:           "sets ID in header",
-			err:            &ErrMisconfiguration,
+			err:            ErrMisconfiguration(),
 			expectedHeader: "invalid_configuration",
 		},
 		{
 			name:           "sets empty header without ID",
-			err:            &ErrNotFound,
+			err:            ErrNotFound(),
 			expectedHeader: "",
 		},
 		{
@@ -454,7 +454,7 @@ func TestOryErrorIDHeader(t *testing.T) {
 		},
 		{
 			name:           "upstream error sets header",
-			err:            &ErrUpstreamError,
+			err:            ErrUpstreamError(),
 			expectedHeader: "upstream_error",
 		},
 	} {

--- a/plain_test.go
+++ b/plain_test.go
@@ -21,12 +21,12 @@ func TestTextWriterOryErrorIDHeader(t *testing.T) {
 	}{
 		{
 			name:           "error with ID sets header",
-			err:            &ErrMisconfiguration,
+			err:            ErrMisconfiguration(),
 			expectedHeader: "invalid_configuration",
 		},
 		{
 			name:           "error without ID does not set header",
-			err:            &ErrNotFound,
+			err:            ErrNotFound(),
 			expectedHeader: "",
 		},
 		{
@@ -41,7 +41,7 @@ func TestTextWriterOryErrorIDHeader(t *testing.T) {
 		},
 		{
 			name:           "upstream error sets header",
-			err:            &ErrUpstreamError,
+			err:            ErrUpstreamError(),
 			expectedHeader: "upstream_error",
 		},
 	} {


### PR DESCRIPTION
   ### Changes                                                                                                                                             

  **Root cause fix** — error "constants" are replaced with constructor functions
  (`ErrBadRequest()`, `ErrNotFound()`, etc.) that return a fresh `*DefaultError` on every
  call, eliminating shared mutable state between requests.                                                                                                  
  
  **`DefaultError` made pointer-only** — all methods now take pointer receivers, consistent                                                                 
  with Go's rule that a type unsafe to shallow-copy should never be copied implicitly. A                                                                  
  `noCopy` sentinel field causes `go vet`/`go test` to warn on any accidental copy. A                                                                       
  `Clone()` method (using `maps.Clone` for `DetailsField`) provides an explicit, safe copy                                                                
  when one is genuinely needed.                                                                                                                             
  
  **`With*` methods are now setters** — they mutate the receiver in place and return it for                                                                 
  chaining, rather than returning a new copy. The intended usage is                                                                                       
  `ErrFoo().WithReason("…")` — call the constructor, then chain setters on the fresh                                                                        
  instance.                                                                                                                                               

  **Existing shallow copies replaced** — the two sites in `WriteErrorCode` that stripped                                                                    
  `DebugField` via `*de` (raw pointer dereference) now use `Clone()`.
                                                                                                                                                            
  **Race test added** — `TestErrorFunctionsNoDataRace` spawns 200 goroutines each calling a                                                                 
  different constructor and concurrently mutating and reading their own instance; passes
  cleanly under `go test -race`.                                                                                                                            
                                  
---

Note: This is a breaking change.

See Slack for details.

